### PR TITLE
Skip adding a comment in build validation for PRs coming from forked repositories

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -213,7 +213,10 @@ jobs:
       - name: Add Terraform Plan Comment
         id: comment
         uses: actions/github-script@v3
-        if: github.event_name == 'pull_request'
+        # Skip adding a comment if the PR is coming from a forked repo
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
* Skip adding a comment in build validation if the PR is coming from a forked repo
  * See #74 as an example.