### PR TITLE
Fix user/pass mismatch when adding a source

### DIFF
--- a/infra/atlas_database.bicep
+++ b/infra/atlas_database.bicep
@@ -1,6 +1,7 @@
 param location string
 param suffix string
 param keyVaultName string
+param postgresAdminUsername string
 param postgresSku string
 param postgresStorageSize int
 @secure()
@@ -13,7 +14,6 @@ param postgresWebapiAppPassword string
 param localDebug bool = false
 param logAnalyticsWorkspaceId string
 
-var postgresAdminUsername = 'postgres_admin'
 var postgresWebapiAdminUsername = 'ohdsi_admin_user'
 var postgresWebapiAdminRole = 'ohdsi_admin'
 var postgresWebapiAppUsername = 'ohdsi_app_user'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -76,6 +76,8 @@ param postgresWebapiAdminPassword string = uniqueString(newGuid())
 @description('The password for the postgres webapi app user')
 param postgresWebapiAppPassword string = uniqueString(newGuid())
 
+var postgresOMOPCDMUserName = 'postgres_admin'
+
 @secure()
 @description('The password for the postgres OMOP CDM user')
 param postgresOMOPCDMPassword string = uniqueString(newGuid())
@@ -156,6 +158,7 @@ module atlasDatabase 'atlas_database.bicep' = {
     postgresAdminPassword: postgresAdminPassword
     postgresWebapiAdminPassword: postgresWebapiAdminPassword
     postgresWebapiAppPassword: postgresWebapiAppPassword
+    postgresAdminUsername: postgresOMOPCDMUserName
     localDebug: localDebug
     logAnalyticsWorkspaceId: logAnalyticsWorkspace.id
   }
@@ -293,7 +296,7 @@ resource deplymentAddDataSource 'Microsoft.Resources/deploymentScripts@2020-10-0
     environmentVariables: [
       {
         name: 'CONNECTION_STRING'
-        secureValue: 'jdbc:postgresql://${atlasDatabase.outputs.postgresServerFullyQualifiedDomainName}:5432/${postgresOMOPCDMDatabaseName}?user=postgres_admin&password=${postgresOMOPCDMPassword}&sslmode=require'
+        secureValue: 'jdbc:postgresql://${atlasDatabase.outputs.postgresServerFullyQualifiedDomainName}:5432/${postgresOMOPCDMDatabaseName}?user=${postgresOMOPCDMUserName}&password=${postgresOMOPCDMPassword}&sslmode=require'
       }
       {
         name: 'OHDSI_WEBAPI_PASSWORD'
@@ -321,11 +324,11 @@ resource deplymentAddDataSource 'Microsoft.Resources/deploymentScripts@2020-10-0
       }
       {
         name: 'USERNAME'
-        value: atlasDatabase.outputs.postgresWebapiAdminUsername
+        value: postgresOMOPCDMUserName
       }
       {
         name: 'PASSWORD'
-        secureValue: postgresWebapiAdminPassword
+        secureValue: postgresOMOPCDMPassword
       }
       {
         name: 'DAIMON_CDM'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -296,7 +296,7 @@ resource deplymentAddDataSource 'Microsoft.Resources/deploymentScripts@2020-10-0
     environmentVariables: [
       {
         name: 'CONNECTION_STRING'
-        secureValue: 'jdbc:postgresql://${atlasDatabase.outputs.postgresServerFullyQualifiedDomainName}:5432/${postgresOMOPCDMDatabaseName}?user=${postgresOMOPCDMUserName}&password=${postgresOMOPCDMPassword}&sslmode=require'
+        secureValue: omopCDM.outputs.postgresOMOPCDMJDBCConnectionString
       }
       {
         name: 'OHDSI_WEBAPI_PASSWORD'

--- a/infra/omop_cdm.bicep
+++ b/infra/omop_cdm.bicep
@@ -176,3 +176,5 @@ resource deploymentScript 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
     }
   }
 }
+
+output postgresOMOPCDMJDBCConnectionString string = postgresOMOPCDMJDBCConnectionString


### PR DESCRIPTION
Fixes #153 

- Fixed the mismatch, now the user/password match the user/password in the connection string.
- Moved the username `postgres_admin` to a variable